### PR TITLE
Refactor call_llm to accept prebuilt messages

### DIFF
--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Optional, List, Dict
 from openai import OpenAI
 
 def make_client(api_key: Optional[str] = None,
@@ -13,13 +13,10 @@ def make_client(api_key: Optional[str] = None,
         default_headers={"x-friendli-team": team_id},
     )
 
-def call_llm(client: OpenAI, model: str, system_prompt: str, user_text: str, **kw) -> str:
+def call_llm(client: OpenAI, model: str, messages: List[Dict[str, str]], **kw) -> str:
     resp = client.chat.completions.create(
         model=model,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_text},
-        ],
+        messages=messages,
         **kw
     )
     return resp.choices[0].message.content


### PR DESCRIPTION
## Summary
- Simplify LLM client call to accept a full `messages` list
- Remove system/user text parameters and pass messages through unchanged

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68af97f004788327905776dbf928c303