### PR TITLE
Add multi-turn option for payload execution

### DIFF
--- a/main_Llama-4-Scout-17B-16E-Instruct.py
+++ b/main_Llama-4-Scout-17B-16E-Instruct.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import payloads as PL
 from utils import make_client, run_all_payloads, run_single_payload
 
@@ -10,6 +11,21 @@ EXP_ROOT_DIR = Path(r"C:\Users\hanky\OneDrive\Desktop\서울대학교\IDEA 연�
 
 # 환경변수 FRIENDLI_API_KEY / FRIENDLI_TEAM_ID 사용 권장
 client = make_client(api_key="flp_YzhZtTDMj0hZfLeVK5YROilYtKIVtH2YgxWX2zlr8s2o2e", team_id="l9h8CAleMYvh")
+
+
+def _load_multi_turn():
+    cfg_path = Path("config.json")
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            return bool(cfg.get("multi_turn", False))
+        except Exception:
+            pass
+    ans = input("Enable multi-turn? [y/N]: ")
+    return ans.strip().lower() in {"y", "yes"}
+
+
+MULTI_TURN = _load_multi_turn()
 
 def _resolve_prompt_path(prompt_dir: Path, n: int):
     for name in (f"Promt{n}.txt", f"Prompt{n}.txt", f"promt{n}.txt", f"prompt{n}.txt"):
@@ -26,6 +42,7 @@ if _prompt_path:
 else:
     print(f"[BOOT] Prompt: NOT FOUND (number={PROMPT_FILE_NO}, dir={PROMPT_DIR.resolve()})")
 print(f"[BOOT] EXP root: {EXP_ROOT_DIR.resolve()}")
+print(f"[BOOT] Multi-turn: {MULTI_TURN}")
 
 # ===== 2) 전체 실행 =====
 run_all_payloads(
@@ -35,6 +52,7 @@ run_all_payloads(
     prompt_dir=PROMPT_DIR,
     prompt_file_no=PROMPT_FILE_NO,
     exp_root_dir=EXP_ROOT_DIR,
+    multi_turn=MULTI_TURN,
 )
 
 # ===== 3) 단일 실행 예시 =====
@@ -47,4 +65,5 @@ run_all_payloads(
 #     prompt_file_no=PROMPT_FILE_NO,
 #     exp_root_dir=EXP_ROOT_DIR,
 #     output_prefix="test_1_4_try1",  # 옵션
+#     multi_turn=MULTI_TURN,
 # )

--- a/main_Qwen3-32B.py
+++ b/main_Qwen3-32B.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import payloads as PL
 from utils import make_client, run_all_payloads, run_single_payload
 
@@ -10,6 +11,21 @@ EXP_ROOT_DIR = Path(r"C:\Users\hanky\OneDrive\Desktop\서울대학교\IDEA 연�
 
 # 환경변수 FRIENDLI_API_KEY / FRIENDLI_TEAM_ID 사용 권장
 client = make_client(api_key="flp_RevIxEFxsulZASUQ2pxyioWev5YI3lJ0bn7ZarCqSWZM80", team_id="l9h8CAleMYvh")
+
+
+def _load_multi_turn():
+    cfg_path = Path("config.json")
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            return bool(cfg.get("multi_turn", False))
+        except Exception:
+            pass
+    ans = input("Enable multi-turn? [y/N]: ")
+    return ans.strip().lower() in {"y", "yes"}
+
+
+MULTI_TURN = _load_multi_turn()
 
 def _resolve_prompt_path(prompt_dir: Path, n: int):
     for name in (f"Promt{n}.txt", f"Prompt{n}.txt", f"promt{n}.txt", f"prompt{n}.txt"):
@@ -26,6 +42,7 @@ if _prompt_path:
 else:
     print(f"[BOOT] Prompt: NOT FOUND (number={PROMPT_FILE_NO}, dir={PROMPT_DIR.resolve()})")
 print(f"[BOOT] EXP root: {EXP_ROOT_DIR.resolve()}")
+print(f"[BOOT] Multi-turn: {MULTI_TURN}")
 
 # ===== 2) 전체 실행 =====
 run_all_payloads(
@@ -35,6 +52,7 @@ run_all_payloads(
     prompt_dir=PROMPT_DIR,
     prompt_file_no=PROMPT_FILE_NO,
     exp_root_dir=EXP_ROOT_DIR,
+    multi_turn=MULTI_TURN,
 )
 
 # ===== 3) 단일 실행 예시 =====
@@ -47,4 +65,5 @@ run_all_payloads(
 #     prompt_file_no=PROMPT_FILE_NO,
 #     exp_root_dir=EXP_ROOT_DIR,
 #     output_prefix="test_1_4_try1",  # 옵션
+#     multi_turn=MULTI_TURN,
 # )

--- a/main_gpt-3.5-turbo.py
+++ b/main_gpt-3.5-turbo.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import json
 import payloads as PL
 from utils import run_all_payloads, run_single_payload
 from openai import OpenAI
@@ -12,6 +13,21 @@ EXP_ROOT_DIR = Path(r"C:\Users\hanky\OneDrive\Desktop\서울대학교\IDEA 연�
 
 # 환경변수 OPENAI_API_KEY 권장
 client = OpenAI(api_key="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")
+
+
+def _load_multi_turn():
+    cfg_path = Path("config.json")
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            return bool(cfg.get("multi_turn", False))
+        except Exception:
+            pass
+    ans = input("Enable multi-turn? [y/N]: ")
+    return ans.strip().lower() in {"y", "yes"}
+
+
+MULTI_TURN = _load_multi_turn()
 
 def _resolve_prompt_path(prompt_dir: Path, n: int):
     for name in (f"Promt{n}.txt", f"Prompt{n}.txt", f"promt{n}.txt", f"prompt{n}.txt"):
@@ -28,6 +44,7 @@ if _prompt_path:
 else:
     print(f"[BOOT] Prompt: NOT FOUND (number={PROMPT_FILE_NO}, dir={PROMPT_DIR.resolve()})")
 print(f"[BOOT] EXP root: {EXP_ROOT_DIR.resolve()}")
+print(f"[BOOT] Multi-turn: {MULTI_TURN}")
 
 # ===== 전체 실행 =====
 run_all_payloads(
@@ -37,6 +54,7 @@ run_all_payloads(
     prompt_dir=PROMPT_DIR,
     prompt_file_no=PROMPT_FILE_NO,
     exp_root_dir=EXP_ROOT_DIR,
+    multi_turn=MULTI_TURN,
 )
 
 # ===== 단일 실행 예시 =====
@@ -49,4 +67,5 @@ run_all_payloads(
 #     prompt_file_no=PROMPT_FILE_NO,
 #     exp_root_dir=EXP_ROOT_DIR,
 #     output_prefix="test_1_4_try1",
+#     multi_turn=MULTI_TURN,
 # )


### PR DESCRIPTION
## Summary
- allow `run_single_payload` and `run_all_payloads` to accept a `multi_turn` flag and log the mode
- read multi-turn setting from `config.json` or user input in all entry scripts
- display the chosen multi-turn mode in startup logs and forward flag to payload runners

## Testing
- `python -m py_compile utils/runner.py main_gpt-3.5-turbo.py main_Qwen3-32B.py main_Llama-4-Scout-17B-16E-Instruct.py`


------
https://chatgpt.com/codex/tasks/task_e_68af97f5b6e88327b1b761b2ce8e2905