### PR TITLE
feat: add multi-turn LLM client

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,9 @@
 from .runner import run_single_payload, run_all_payloads
 from .llm_client import make_client, call_llm
+
+__all__ = [
+    "run_single_payload",
+    "run_all_payloads",
+    "make_client",
+    "call_llm",
+]

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -2,9 +2,12 @@ import os
 from typing import Optional, List, Dict
 from openai import OpenAI
 
-def make_client(api_key: Optional[str] = None,
-                team_id: Optional[str] = None,
-                base_url: str = "https://api.friendli.ai/serverless/v1") -> OpenAI:
+
+def make_client(
+    api_key: Optional[str] = None,
+    team_id: Optional[str] = None,
+    base_url: str = "https://api.friendli.ai/serverless/v1",
+) -> OpenAI:
     api_key = api_key or os.getenv("FRIENDLI_API_KEY", "REPLACE_ME")
     team_id = team_id or os.getenv("FRIENDLI_TEAM_ID", "REPLACE_ME")
     return OpenAI(
@@ -13,10 +16,62 @@ def make_client(api_key: Optional[str] = None,
         default_headers={"x-friendli-team": team_id},
     )
 
-def call_llm(client: OpenAI, model: str, messages: List[Dict[str, str]], **kw) -> str:
-    resp = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        **kw
-    )
-    return resp.choices[0].message.content
+
+def call_llm(
+    client: OpenAI,
+    model: str,
+    system_prompt: str,
+    user_question: str,
+    *,
+    multi_turn: bool = False,
+    max_turns: int = 5,
+    **kw,
+) -> str:
+    """Call LLM with optional multi-turn clarification.
+
+    Parameters
+    ----------
+    client : OpenAI
+        OpenAI client instance.
+    model : str
+        Model name.
+    system_prompt : str
+        Prompt describing the task and available metadata.
+    user_question : str
+        The original question from user.
+    multi_turn : bool, optional
+        If True, the assistant may ask follow-up questions when the
+        request is ambiguous. Conversation continues until the model
+        returns a message containing a code block or the maximum number
+        of turns is reached.
+    max_turns : int, optional
+        Maximum number of clarification turns.
+
+    Returns
+    -------
+    str
+        Final assistant message (expected to include code block).
+    """
+
+    messages: List[Dict[str, str]] = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_question},
+    ]
+
+    for _ in range(max_turns):
+        resp = client.chat.completions.create(
+            model=model, messages=messages, **kw
+        )
+        content = resp.choices[0].message.content
+        messages.append({"role": "assistant", "content": content})
+
+        if multi_turn and "```" not in content:
+            # LLM is likely asking for clarification
+            print(content)
+            user_reply = input("User: ")
+            messages.append({"role": "user", "content": user_reply})
+            continue
+
+        return content
+
+    raise RuntimeError("Max turns exceeded without reaching final answer")


### PR DESCRIPTION
## Summary
- add interactive multi-turn support in LLM client to handle clarifying questions
- fix utils package exports

## Testing
- `python -m py_compile utils/__init__.py utils/llm_client.py`
- `pip install openai -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afea4a88708327bd85edd8f9a0f467