### PR TITLE
Add FastAPI chat server and refactor LLM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Friendli-Ai_multi_turn
+
+## FastAPI Server
+
+Run the HTTP server with:
+
+```bash
+uvicorn server:app --reload
+```
+
+The server exposes `POST /chat/{session_id}` for chatting with the LLM. Each
+session maintains its own message history in memory.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,40 @@
+import os
+from typing import Dict, List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from utils import make_client, call_llm
+
+app = FastAPI()
+
+# In-memory storage of conversation per session
+_sessions: Dict[str, List[Dict[str, str]]] = {}
+
+MODEL = os.getenv("FRIENDLI_MODEL", "gpt-4o-mini")
+DEFAULT_SYSTEM = os.getenv("SYSTEM_PROMPT", "You are a helpful assistant.")
+
+
+class ChatRequest(BaseModel):
+    message: str
+    system_prompt: str | None = None
+
+
+@app.post("/chat/{session_id}")
+async def chat(session_id: str, req: ChatRequest):
+    """Handle a chat message for the given session."""
+    messages = _sessions.setdefault(session_id, [])
+
+    # Initialize session with system prompt when first message arrives
+    if not messages:
+        system = req.system_prompt or DEFAULT_SYSTEM
+        messages.append({"role": "system", "content": system})
+
+    # Append user message
+    messages.append({"role": "user", "content": req.message})
+
+    client = make_client()
+    answer = call_llm(client, MODEL, messages=messages)
+    messages.append({"role": "assistant", "content": answer})
+
+    return {"question": req.message, "answer": answer}


### PR DESCRIPTION
## Summary
- refactor `call_llm` to accept message lists instead of interactive input
- add `server.py` with `/chat/{session_id}` FastAPI endpoint and per-session history
- document server startup command

## Testing
- `python -m py_compile server.py utils/llm_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68afed6b91808327a853b46acda06667