### PR TITLE
Add FastAPI chat server with API-friendly LLM helper

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Dict, List
+
+from utils import make_client, call_llm
+
+app = FastAPI()
+client = make_client()
+
+# Load default system prompt used by existing scripts
+with open("system_prompt/Prompt3.txt", encoding="utf-8") as f:
+    SYSTEM_PROMPT = f.read()
+
+# In-memory storage of conversation histories
+sessions: Dict[str, List[Dict[str, str]]] = {}
+
+class ChatRequest(BaseModel):
+    message: str
+
+class ChatResponse(BaseModel):
+    content: str
+    needs_reply: bool
+
+@app.post("/chat/{session_id}", response_model=ChatResponse)
+async def chat(session_id: str, req: ChatRequest) -> ChatResponse:
+    """Chat endpoint that maintains session-specific conversation."""
+    history = sessions.setdefault(session_id, [])
+
+    result = call_llm(
+        client,
+        model="gpt-3.5-turbo",
+        system_prompt=SYSTEM_PROMPT,
+        user_question=req.message,
+        history=history,
+        user_reply=req.message if history else None,
+        multi_turn=True,
+    )
+
+    # Record dialogue
+    history.append({"role": "user", "content": req.message})
+    history.append({"role": "assistant", "content": result["content"]})
+
+    if not result["needs_reply"]:
+        # Conversation finished; clean up session
+        sessions.pop(session_id, None)
+
+    return ChatResponse(**result)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,9 @@
 from .runner import run_single_payload, run_all_payloads
 from .llm_client import make_client, call_llm
+
+__all__ = [
+    "run_single_payload",
+    "run_all_payloads",
+    "make_client",
+    "call_llm",
+]

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -2,9 +2,12 @@ import os
 from typing import Optional, List, Dict
 from openai import OpenAI
 
-def make_client(api_key: Optional[str] = None,
-                team_id: Optional[str] = None,
-                base_url: str = "https://api.friendli.ai/serverless/v1") -> OpenAI:
+
+def make_client(
+    api_key: Optional[str] = None,
+    team_id: Optional[str] = None,
+    base_url: str = "https://api.friendli.ai/serverless/v1",
+) -> OpenAI:
     api_key = api_key or os.getenv("FRIENDLI_API_KEY", "REPLACE_ME")
     team_id = team_id or os.getenv("FRIENDLI_TEAM_ID", "REPLACE_ME")
     return OpenAI(
@@ -13,10 +16,62 @@ def make_client(api_key: Optional[str] = None,
         default_headers={"x-friendli-team": team_id},
     )
 
-def call_llm(client: OpenAI, model: str, messages: List[Dict[str, str]], **kw) -> str:
+
+def call_llm(
+    client: OpenAI,
+    model: str,
+    system_prompt: str,
+    user_question: str,
+    *,
+    history: Optional[List[Dict[str, str]]] = None,
+    user_reply: Optional[str] = None,
+    multi_turn: bool = False,
+    **kw,
+) -> Dict[str, object]:
+    """Call LLM and return whether more user input is required.
+
+    Parameters
+    ----------
+    client : OpenAI
+        OpenAI client instance.
+    model : str
+        Model name.
+    system_prompt : str
+        Prompt describing the task and available metadata.
+    user_question : str
+        The original question from user. Used when ``history`` is empty.
+    history : list of dict, optional
+        Previous conversation messages excluding the system prompt.
+    user_reply : str, optional
+        Reply from the user for a follow-up question.
+    multi_turn : bool, optional
+        If True, the assistant may ask follow-up questions when the
+        request is ambiguous.
+
+    Returns
+    -------
+    dict
+        ``{"content": str, "needs_reply": bool}``
+    """
+
+    messages: List[Dict[str, str]] = [
+        {"role": "system", "content": system_prompt}
+    ]
+    if history:
+        messages.extend(history)
+
+    if user_reply is not None:
+        messages.append({"role": "user", "content": user_reply})
+    else:
+        messages.append({"role": "user", "content": user_question})
+
     resp = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        **kw
+        model=model, messages=messages, **kw
     )
-    return resp.choices[0].message.content
+    content = resp.choices[0].message.content
+    needs_reply = multi_turn and "```" not in content
+
+    return {
+        "content": content,
+        "needs_reply": needs_reply,
+    }


### PR DESCRIPTION
## Summary
- refactor call_llm to accept history and user replies so responses can indicate when more input is needed
- create FastAPI server with session-based multi-turn chat endpoint

## Testing
- `python -m py_compile utils/llm_client.py server.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afea4a88708327bd85edd8f9a0f467